### PR TITLE
Fix Dockerfile entrypoint typo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN ARCH=$(uname -m); \
 COPY . /tmp/cleaner
 RUN pip install --no-cache /tmp/cleaner
 
-ENTRYPOINT [ "/tini", "--", "/usr/local/bin/acme-secret-sync.py" ]
+ENTRYPOINT [ "/tini", "--", "docker-image-cleaner" ]


### PR DESCRIPTION
Followup of #6 that introduced a regression of the Dockerfile command because of a copy paste that wasn't modified to fit this project properly.

I'd love to add a quick and basic startup test, but this image doesn't work straight away without additional configuration so its a bit troublesome to do so.