### PR TITLE
pre-commit: use isort over reorder-python-imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,10 +25,12 @@ repos:
         args: [--target-version=py36]
 
   # Autoformat: Python code
-  - repo: https://github.com/asottile/reorder_python_imports
-    rev: v3.1.0
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
     hooks:
-      - id: reorder-python-imports
+      - id: isort
+        args:
+          - --profile=black
 
   # Autoformat: markdown, yaml, json
   - repo: https://github.com/pre-commit/mirrors-prettier

--- a/docker_image_cleaner/cleaner.py
+++ b/docker_image_cleaner/cleaner.py
@@ -10,13 +10,11 @@ at this time.
 import logging
 import os
 import time
-from contextlib import contextmanager
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from functools import partial
 
 import docker
 import requests
-
 
 logging.basicConfig(format="%(asctime)s %(message)s", level=logging.INFO)
 
@@ -108,8 +106,8 @@ def main():
 
     node = os.getenv("NODE_NAME")
     if node:
-        import kubernetes.config
         import kubernetes.client
+        import kubernetes.config
 
         try:
             kubernetes.config.load_incluster_config()

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
-from setuptools import find_packages
-from setuptools import setup
+from setuptools import find_packages, setup
 
 with open(Path(__file__).parent / "requirements.in") as f:
     requirements = [l.strip() for l in f.readlines() if not l.strip().startswith("#")]


### PR DESCRIPTION
- pre-commit: use isort instead of reorder-python-imports
- pre-commit: run isort
