### PR TITLE
breaking, maint: require py38+

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,14 +15,17 @@ repos:
     hooks:
       - id: pyupgrade
         args:
-          - --py36-plus
+          - --py38-plus
 
   # Autoformat: Python code
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:
       - id: black
-        args: [--target-version=py36]
+        args:
+          - --target-version=py38
+          - --target-version=py39
+          - --target-version=py310
 
   # Autoformat: Python code
   - repo: https://github.com/pycqa/isort

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     # SemVer 2: https://semver.org
     #
     version="1.0.0-beta.1",
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     author="Project Jupyter Contributors",
     author_email="jupyter@googlegroups.com",
     license="BSD",


### PR DESCRIPTION
We run this in a controlled environment, so require py38+ should be fine.

I'm making some quick fixes to this repo, including breaking changes, for a 1.0.0 releases. I especially want to rename some env variables because they made me confused when learning about binderhub.