### PR TITLE
breaking, maint: prefix env vars with project name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## 1.0
 
+### 1.0.0-beta.2 - Not yet released
+
+#### Breaking changes
+
+All environment variables configuring the docker-image-cleaner has been renamed
+but have the same functionality.
+
+| Before                    | After                                    |
+| ------------------------- | ---------------------------------------- |
+| `NODE_NAME`               | `DOCKER_IMAGE_CLEANER__NODE_NAME`        |
+| `PATH_TO_CHECK`           | `DOCKER_IMAGE_CLEANER__PATH_TO_CHECK`    |
+| `IMAGE_GC_INTERVAL`       | `DOCKER_IMAGE_CLEANER__INTERVAL_SECONDS` |
+| `IMAGE_GC_DELAY`          | `DOCKER_IMAGE_CLEANER__DELAY_SECONDS`    |
+| `IMAGE_GC_THRESHOLD_TYPE` | `DOCKER_IMAGE_CLEANER__THRESHOLD_TYPE`   |
+| `IMAGE_GC_THRESHOLD_HIGH` | `DOCKER_IMAGE_CLEANER__THRESHOLD_HIGH`   |
+| `IMAGE_GC_THRESHOLD_LOW`  | `DOCKER_IMAGE_CLEANER__THRESHOLD_LOW`    |
+
 ### 1.0.0-beta.1 - 2022-05-25
 
 #### Enhancements made

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,15 @@
 All environment variables configuring the docker-image-cleaner has been renamed
 but have the same functionality.
 
-| Before                    | After                                    |
-| ------------------------- | ---------------------------------------- |
-| `NODE_NAME`               | `DOCKER_IMAGE_CLEANER__NODE_NAME`        |
-| `PATH_TO_CHECK`           | `DOCKER_IMAGE_CLEANER__PATH_TO_CHECK`    |
-| `IMAGE_GC_INTERVAL`       | `DOCKER_IMAGE_CLEANER__INTERVAL_SECONDS` |
-| `IMAGE_GC_DELAY`          | `DOCKER_IMAGE_CLEANER__DELAY_SECONDS`    |
-| `IMAGE_GC_THRESHOLD_TYPE` | `DOCKER_IMAGE_CLEANER__THRESHOLD_TYPE`   |
-| `IMAGE_GC_THRESHOLD_HIGH` | `DOCKER_IMAGE_CLEANER__THRESHOLD_HIGH`   |
-| `IMAGE_GC_THRESHOLD_LOW`  | `DOCKER_IMAGE_CLEANER__THRESHOLD_LOW`    |
+| Before                    | After                                   |
+| ------------------------- | --------------------------------------- |
+| `NODE_NAME`               | `DOCKER_IMAGE_CLEANER_NODE_NAME`        |
+| `PATH_TO_CHECK`           | `DOCKER_IMAGE_CLEANER_PATH_TO_CHECK`    |
+| `IMAGE_GC_INTERVAL`       | `DOCKER_IMAGE_CLEANER_INTERVAL_SECONDS` |
+| `IMAGE_GC_DELAY`          | `DOCKER_IMAGE_CLEANER_DELAY_SECONDS`    |
+| `IMAGE_GC_THRESHOLD_TYPE` | `DOCKER_IMAGE_CLEANER_THRESHOLD_TYPE`   |
+| `IMAGE_GC_THRESHOLD_HIGH` | `DOCKER_IMAGE_CLEANER_THRESHOLD_HIGH`   |
+| `IMAGE_GC_THRESHOLD_LOW`  | `DOCKER_IMAGE_CLEANER_THRESHOLD_LOW`    |
 
 ### 1.0.0-beta.1 - 2022-05-25
 

--- a/README.md
+++ b/README.md
@@ -42,32 +42,32 @@ garbage collection in a configurable way.
 ## How does it work?
 
 1. Compute how much space `/var/lib/docker` directory (specified by the
-   `DOCKER_IMAGE_CLEANER__PATH_TO_CHECK` environment variable) is taking up.
+   `DOCKER_IMAGE_CLEANER_PATH_TO_CHECK` environment variable) is taking up.
 2. If the disk space used is greater than the garbage collection trigger threshold
-   (specified by `DOCKER_IMAGE_CLEANER__THRESHOLD_HIGH`), garbage collection is triggered.
-   If not, the script just waits another 5 minutes (set by `DOCKER_IMAGE_CLEANER__INTERVAL_SECONDS`).
+   (specified by `DOCKER_IMAGE_CLEANER_THRESHOLD_HIGH`), garbage collection is triggered.
+   If not, the script just waits another 5 minutes (set by `DOCKER_IMAGE_CLEANER_INTERVAL_SECONDS`).
 3. If garbage collection is triggered, the kubernetes node is first cordoned
    to prevent any new pods from being scheduled on it for the duration of the
    garbage collection.
 4. Unused container images are deleted one by one, starting with the biggest,
    until the disk space used by `/var/lib/docker` falls below the garbage collection
-   'ok' threshold (specified by `DOCKER_IMAGE_CLEANER__THRESHOLD_LOW`). This low / high system
+   'ok' threshold (specified by `DOCKER_IMAGE_CLEANER_THRESHOLD_LOW`). This low / high system
    makes sure we don't get too aggressive in cleaning the disk, as images being
    present on the node does speed up binderhub launches.
 5. After the garbage collection is done, the kubernetes node is also uncordoned.
-6. When done, we wait another 5 minutes (set by `DOCKER_IMAGE_CLEANER__INTERVAL_SECONDS`), and repeat
+6. When done, we wait another 5 minutes (set by `DOCKER_IMAGE_CLEANER_INTERVAL_SECONDS`), and repeat
    the whole process.
 
 ## Configuration options
 
 Currently, environment variables are used to set configuration for now.
 
-| Env variable                             | Description                                                                                                                     | Default           |
-| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| `DOCKER_IMAGE_CLEANER__NODE_NAME`        | The k8s node where the docker image cleaner is running, so it can be cordoned via the k8s api                                   |                   |
-| `DOCKER_IMAGE_CLEANER__PATH_TO_CHECK`    | Path to `/var/lib/docker` directory used by the docker daemon                                                                   | `/var/lib/docker` |
-| `DOCKER_IMAGE_CLEANER__INTERVAL_SECONDS` | Amount of time (in seconds) to wait between checking if GC needs to be triggered                                                | `300`             |
-| `DOCKER_IMAGE_CLEANER__DELAY_SECONDS`    | Amount of time (in seconds) to wait between deleting container images, so we don't DOS the docker API                           | `1`               |
-| `DOCKER_IMAGE_CLEANER__THRESHOLD_TYPE`   | Determine if GC should be triggered based on relative or absolute disk usage                                                    | `relative`        |
-| `DOCKER_IMAGE_CLEANER__THRESHOLD_HIGH`   | % or absolute disk space available (based on `DOCKER_IMAGE_CLEANER__THRESHOLD_TYPE`) when we start deleting container images    | `80`              |
-| `DOCKER_IMAGE_CLEANER__THRESHOLD_LOW`    | % or absolute disk space available (based on `DOCKER_IMAGE_CLEANER__THRESHOLD_TYPE`) when we can stop deleting container images | `60`              |
+| Env variable                            | Description                                                                                                                    | Default           |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ----------------- |
+| `DOCKER_IMAGE_CLEANER_NODE_NAME`        | The k8s node where the docker image cleaner is running, so it can be cordoned via the k8s api                                  |                   |
+| `DOCKER_IMAGE_CLEANER_PATH_TO_CHECK`    | Path to `/var/lib/docker` directory used by the docker daemon                                                                  | `/var/lib/docker` |
+| `DOCKER_IMAGE_CLEANER_INTERVAL_SECONDS` | Amount of time (in seconds) to wait between checking if GC needs to be triggered                                               | `300`             |
+| `DOCKER_IMAGE_CLEANER_DELAY_SECONDS`    | Amount of time (in seconds) to wait between deleting container images, so we don't DOS the docker API                          | `1`               |
+| `DOCKER_IMAGE_CLEANER_THRESHOLD_TYPE`   | Determine if GC should be triggered based on relative or absolute disk usage                                                   | `relative`        |
+| `DOCKER_IMAGE_CLEANER_THRESHOLD_HIGH`   | % or absolute disk space available (based on `DOCKER_IMAGE_CLEANER_THRESHOLD_TYPE`) when we start deleting container images    | `80`              |
+| `DOCKER_IMAGE_CLEANER_THRESHOLD_LOW`    | % or absolute disk space available (based on `DOCKER_IMAGE_CLEANER_THRESHOLD_TYPE`) when we can stop deleting container images | `60`              |

--- a/README.md
+++ b/README.md
@@ -42,31 +42,32 @@ garbage collection in a configurable way.
 ## How does it work?
 
 1. Compute how much space `/var/lib/docker` directory (specified by the
-   `PATH_TO_CHECK` environment variable) is taking up.
+   `DOCKER_IMAGE_CLEANER__PATH_TO_CHECK` environment variable) is taking up.
 2. If the disk space used is greater than the garbage collection trigger threshold
-   (specified by `IMAGE_GC_THRESHOLD_HIGH`), garbage collection is triggered.
-   If not, the script just waits another 5 minutes (set by `IMAGE_GC_INTERVAL`).
+   (specified by `DOCKER_IMAGE_CLEANER__THRESHOLD_HIGH`), garbage collection is triggered.
+   If not, the script just waits another 5 minutes (set by `DOCKER_IMAGE_CLEANER__INTERVAL_SECONDS`).
 3. If garbage collection is triggered, the kubernetes node is first cordoned
    to prevent any new pods from being scheduled on it for the duration of the
    garbage collection.
 4. Unused container images are deleted one by one, starting with the biggest,
    until the disk space used by `/var/lib/docker` falls below the garbage collection
-   'ok' threshold (specified by `IMAGE_GC_THRESHOLD_LOW`). This low / high system
+   'ok' threshold (specified by `DOCKER_IMAGE_CLEANER__THRESHOLD_LOW`). This low / high system
    makes sure we don't get too aggressive in cleaning the disk, as images being
    present on the node does speed up binderhub launches.
 5. After the garbage collection is done, the kubernetes node is also uncordoned.
-6. When done, we wait another 5 minutes (set by `IMAGE_GC_INTERVAL`), and repeat
+6. When done, we wait another 5 minutes (set by `DOCKER_IMAGE_CLEANER__INTERVAL_SECONDS`), and repeat
    the whole process.
 
 ## Configuration options
 
 Currently, environment variables are used to set configuration for now.
 
-| Env variable              | Description                                                                                                        | Default           |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------ | ----------------- |
-| `PATH_TO_CHECK`           | Path to `/var/lib/docker` directory used by the docker daemon                                                      | `/var/lib/docker` |
-| `IMAGE_GC_INTERVAL`       | Amount of time (in seconds) to wait between checking if GC needs to be triggered                                   | `300`             |
-| `IMAGE_GC_DELAY`          | Amount of time (in seconds) to wait between deleting container images, so we don't DOS the docker API              | `1`               |
-| `IMAGE_GC_THRESHOLD_TYPE` | Determine if GC should be triggered based on relative or absolute disk usage                                       | `relative`        |
-| `IMAGE_GC_THRESHOLD_HIGH` | % or absolute disk space available (based on `IMAGE_GC_THRESHOLD_TYPE`) when we start deleting container images    | `80`              |
-| `IMAGE_GC_THRESHOLD_LOW`  | % or absolute disk space available (based on `IMAGE_GC_THRESHOLD_TYPE`) when we can stop deleting container images | `60`              |
+| Env variable                             | Description                                                                                                                     | Default           |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| `DOCKER_IMAGE_CLEANER__NODE_NAME`        | The k8s node where the docker image cleaner is running, so it can be cordoned via the k8s api                                   |                   |
+| `DOCKER_IMAGE_CLEANER__PATH_TO_CHECK`    | Path to `/var/lib/docker` directory used by the docker daemon                                                                   | `/var/lib/docker` |
+| `DOCKER_IMAGE_CLEANER__INTERVAL_SECONDS` | Amount of time (in seconds) to wait between checking if GC needs to be triggered                                                | `300`             |
+| `DOCKER_IMAGE_CLEANER__DELAY_SECONDS`    | Amount of time (in seconds) to wait between deleting container images, so we don't DOS the docker API                           | `1`               |
+| `DOCKER_IMAGE_CLEANER__THRESHOLD_TYPE`   | Determine if GC should be triggered based on relative or absolute disk usage                                                    | `relative`        |
+| `DOCKER_IMAGE_CLEANER__THRESHOLD_HIGH`   | % or absolute disk space available (based on `DOCKER_IMAGE_CLEANER__THRESHOLD_TYPE`) when we start deleting container images    | `80`              |
+| `DOCKER_IMAGE_CLEANER__THRESHOLD_LOW`    | % or absolute disk space available (based on `DOCKER_IMAGE_CLEANER__THRESHOLD_TYPE`) when we can stop deleting container images | `60`              |

--- a/docker_image_cleaner/cleaner.py
+++ b/docker_image_cleaner/cleaner.py
@@ -104,7 +104,7 @@ def cordoned(kube, node):
 
 def main():
 
-    node = os.getenv("NODE_NAME")
+    node = os.getenv("DOCKER_IMAGE_CLEANER__NODE_NAME")
     if node:
         import kubernetes.client
         import kubernetes.config
@@ -129,12 +129,12 @@ def main():
     else:
         cordon_context = nullcontext
 
-    path_to_check = os.getenv("PATH_TO_CHECK", "/var/lib/docker")
-    interval = float(os.getenv("IMAGE_GC_INTERVAL", "300"))
-    delay = float(os.getenv("IMAGE_GC_DELAY", "1"))
-    gc_threshold_type = os.getenv("IMAGE_GC_THRESHOLD_TYPE", "relative")
-    gc_low = float(os.getenv("IMAGE_GC_THRESHOLD_LOW", "60"))
-    gc_high = float(os.getenv("IMAGE_GC_THRESHOLD_HIGH", "80"))
+    path_to_check = os.getenv("DOCKER_IMAGE_CLEANER__PATH_TO_CHECK", "/var/lib/docker")
+    interval_seconds = float(os.getenv("DOCKER_IMAGE_CLEANER__INTERVAL_SECONDS", "300"))
+    delay_seconds = float(os.getenv("DOCKER_IMAGE_CLEANER__DELAY_SECONDS", "1"))
+    threshold_type = os.getenv("DOCKER_IMAGE_CLEANER__THRESHOLD_TYPE", "relative")
+    threshold_low = float(os.getenv("DOCKER_IMAGE_CLEANER__THRESHOLD_LOW", "60"))
+    threshold_high = float(os.getenv("DOCKER_IMAGE_CLEANER__THRESHOLD_HIGH", "80"))
 
     docker_client = docker.from_env(version="auto")
 
@@ -143,36 +143,36 @@ def main():
     # thresholds are interpreted as size in bytes. By default you should use
     # "relative" mode. Use "absolute" mode when you are using DIND and your
     # nodes only have one partition.
-    if gc_threshold_type == "relative":
+    if threshold_type == "relative":
         get_used = get_used_percent
         used_msg = "{used:.1f}% used"
-        threshold_s = f"{gc_high}% inodes or blocks"
+        threshold_s = f"{threshold_high}% inodes or blocks"
     else:
         get_used = get_absolute_size
         used_msg = "{used:.2f}GB used"
-        threshold_s = f"{gc_high // (2**30):.0f}GB"
+        threshold_s = f"{threshold_high // (2**30):.0f}GB"
 
-        if gc_high <= 2**30:
+        if threshold_high <= 2**30:
             raise ValueError(
-                f"Absolute GC threshold should be at least 1GB, got {gc_high}B"
+                f"Absolute GC threshold should be at least 1GB, got {threshold_high}B"
             )
         # units in GB
-        gc_high = gc_high / (2**30)
+        threshold_high = threshold_high / (2**30)
 
     logging.info(f"Pruning docker images when {path_to_check} has {threshold_s} used")
 
     while True:
         used = get_used(path_to_check)
         logging.info(used_msg.format(used=used))
-        if used < gc_high:
+        if used < threshold_high:
             # Do nothing! We have enough space
-            time.sleep(interval)
+            time.sleep(interval_seconds)
             continue
 
         images = docker_client.images.list(all=True)
         if not images:
             logging.info("No images to delete")
-            time.sleep(interval)
+            time.sleep(interval_seconds)
             continue
         else:
             logging.info(f"{len(images)} images available to prune")
@@ -189,7 +189,7 @@ def main():
                 except requests.exceptions.ReadTimeout:
                     logging.warning(f"Timeout pruning {kind}")
                     # Delay longer after a timeout, which indicates that Docker is overworked
-                    time.sleep(max(delay, 30))
+                    time.sleep(max(delay_seconds, 30))
                     continue
 
                 toc = time.perf_counter()
@@ -206,7 +206,7 @@ def main():
                     except requests.exceptions.ReadTimeout:
                         logging.warning("Timeout pruning all images")
                         # Delay longer after a timeout, which indicates that Docker is overworked
-                        time.sleep(max(delay, 30))
+                        time.sleep(max(delay_seconds, 30))
                         continue
                     toc = time.perf_counter()
                     deleted = pruned[key]
@@ -223,7 +223,7 @@ def main():
                     f"Deleted {n_deleted} {kind}, freed {gb:.2f}GB in {duration:.0f} seconds."
                 )
 
-        time.sleep(interval)
+        time.sleep(interval_seconds)
 
 
 if __name__ == "__main__":

--- a/docker_image_cleaner/cleaner.py
+++ b/docker_image_cleaner/cleaner.py
@@ -104,7 +104,7 @@ def cordoned(kube, node):
 
 def main():
 
-    node = os.getenv("DOCKER_IMAGE_CLEANER__NODE_NAME")
+    node = os.getenv("DOCKER_IMAGE_CLEANER_NODE_NAME")
     if node:
         import kubernetes.client
         import kubernetes.config
@@ -129,12 +129,12 @@ def main():
     else:
         cordon_context = nullcontext
 
-    path_to_check = os.getenv("DOCKER_IMAGE_CLEANER__PATH_TO_CHECK", "/var/lib/docker")
-    interval_seconds = float(os.getenv("DOCKER_IMAGE_CLEANER__INTERVAL_SECONDS", "300"))
-    delay_seconds = float(os.getenv("DOCKER_IMAGE_CLEANER__DELAY_SECONDS", "1"))
-    threshold_type = os.getenv("DOCKER_IMAGE_CLEANER__THRESHOLD_TYPE", "relative")
-    threshold_low = float(os.getenv("DOCKER_IMAGE_CLEANER__THRESHOLD_LOW", "60"))
-    threshold_high = float(os.getenv("DOCKER_IMAGE_CLEANER__THRESHOLD_HIGH", "80"))
+    path_to_check = os.getenv("DOCKER_IMAGE_CLEANER_PATH_TO_CHECK", "/var/lib/docker")
+    interval_seconds = float(os.getenv("DOCKER_IMAGE_CLEANER_INTERVAL_SECONDS", "300"))
+    delay_seconds = float(os.getenv("DOCKER_IMAGE_CLEANER_DELAY_SECONDS", "1"))
+    threshold_type = os.getenv("DOCKER_IMAGE_CLEANER_THRESHOLD_TYPE", "relative")
+    threshold_low = float(os.getenv("DOCKER_IMAGE_CLEANER_THRESHOLD_LOW", "60"))
+    threshold_high = float(os.getenv("DOCKER_IMAGE_CLEANER_THRESHOLD_HIGH", "80"))
 
     docker_client = docker.from_env(version="auto")
 


### PR DESCRIPTION
I've wanted to do this for a while, since when I learned about the binderhub helm chart this was a big confusion point for me. With these names, it would be far clearer.

This is a breaking change though, but I only think jupyterhub/binderhub will be affected, and I can transition that config while bumping to this version.