### PR TITLE
image: use frozen requirements.txt and automate updates of it

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,8 +5,23 @@ name: Publish
 
 # Always build releases/images but only publish to PyPI/quay.io on pushed tags
 on:
-  push:
   pull_request:
+    paths:
+      - "Dockerfile"
+      - "requirements.in"
+      - "requirements.txt"
+      - ".github/workflows/refreeze-dockerfile-requirements-txt.yaml"
+  push:
+    paths:
+      - "Dockerfile"
+      - "requirements.in"
+      - "requirements.txt"
+      - ".github/workflows/refreeze-dockerfile-requirements-txt.yaml"
+    branches-ignore:
+      - "dependabot/**"
+      - "pre-commit-ci-update-config"
+      - "update-*"
+    tags: ["**"]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/refreeze-dockerfile-requirements-txt.yaml
+++ b/.github/workflows/refreeze-dockerfile-requirements-txt.yaml
@@ -1,0 +1,59 @@
+# This is a GitHub workflow defining a set of jobs with a set of steps.
+# ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
+#
+name: Refreeze Dockerfile's requirements.txt
+
+on:
+  push:
+    paths:
+      - "**/requirements.in"
+      - "**/requirements.txt"
+      - ".github/workflows/refreeze-dockerfile-requirements-txt.yaml"
+    branches: ["main"]
+    tags: ["**"]
+  workflow_dispatch:
+
+jobs:
+  refreeze-dockerfile-requirements-txt:
+    name: Refreeze Dockerfile's requirements.txt
+
+    # Don't run this job on forks
+    if: github.repository == 'jupyterhub/docker-image-cleaner'
+    runs-on: ubuntu-latest
+
+    environment: refreeze-dockerfile-requirements-txt
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+
+      - name: Refreeze Dockerfile's requirements.txt based on requirements.in
+        run: |
+          cd ${{ matrix.image }}
+          docker run --rm \
+              --env=CUSTOM_COMPILE_COMMAND='Use "Run workflow" button at https://github.com/jupyterhub/docker-image-cleaner/actions/workflows/refreeze-dockerfile-requirements-txt.yaml' \
+              --volume=$PWD:/io \
+              --workdir=/io \
+              --user=root \
+              python:3.9-alpine \
+              sh -c 'pip install pip-tools==6.* && pip-compile --upgrade'
+
+      - name: git diff
+        run: git --no-pager diff --color=always
+
+      # ref: https://github.com/peter-evans/create-pull-request
+      - name: Create a PR
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: "${{ secrets.jupyterhub_bot_pat }}"
+          author: JupyterHub Bot Account <105740858+jupyterhub-bot@users.noreply.github.com>
+          committer: JupyterHub Bot Account <105740858+jupyterhub-bot@users.noreply.github.com>
+          branch: update-image-requirements
+          labels: dependencies
+          commit-message: Refreeze Dockerfile's requirements.txt
+          title: Refreeze Dockerfile's requirements.txt
+          body: >-
+            Dockerfile's requirements.txt has been refrozen based on
+            requirements.in.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+# NOTE: Updates to this image tag should go hand in hand with updates in the
+#       refreeze-dockerfile-requirements-txt.yaml workflow.
+#
 FROM python:3.9-alpine
 
 # Ensures written logs are made available directly
@@ -13,7 +16,10 @@ RUN ARCH=$(uname -m); \
  && chmod +x /tini
 
 # Install docker-image-cleaner
-COPY . /tmp/cleaner
-RUN pip install --no-cache /tmp/cleaner
+COPY . /opt/docker-image-cleaner
+WORKDIR /opt/docker-image-cleaner
+RUN pip install --no-cache-dir \
+        -r requirements.txt \
+        .
 
 ENTRYPOINT [ "/tini", "--", "docker-image-cleaner" ]


### PR DESCRIPTION
We had a requirements.txt file, but wasn't using it via the Dockerfile.

In this PR I made our Dockerfile reference the frozen environment, and I add a workflow that can easily be triggered via a "Run workflow" button to update the requirements.txt file and submit a PR to be merged. I'm using a jupyterhub_bot_pat token to allow tests to be run on update prs being created. The setup of this is done according to steps in https://github.com/jupyterhub/team-compass/issues/516#issuecomment-1129961954.

I'll go for a self-merge and verify functionality as I have time to iterate on it now.