### PR TITLE
Post-releases improvements

### DIFF
--- a/.github/workflows/refreeze-dockerfile-requirements-txt.yaml
+++ b/.github/workflows/refreeze-dockerfile-requirements-txt.yaml
@@ -10,7 +10,6 @@ on:
       - "**/requirements.txt"
       - ".github/workflows/refreeze-dockerfile-requirements-txt.yaml"
     branches: ["main"]
-    tags: ["**"]
   workflow_dispatch:
 
 jobs:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -23,9 +23,8 @@ For you to follow along according to these instructions, you need:
    git clean -xfd
    ```
 
-1. Update [CHANGELOG.md](CHANGELOG.md). Doing this can be made easier with the
-   help of the
-   [choldgraf/github-activity](https://github.com/choldgraf/github-activity)
+1. Update [CHANGELOG.md](CHANGELOG.md) with the help of the
+   [github-activity](https://github-activity.readthedocs.io)
    utility.
 
 1. Set the `version` variable in [setup.py](setup.py) appropriately and make a


### PR DESCRIPTION
refreeze-dockerfile-requirements-txt fails on tags because you can't open a PR against a tag.