### PR TITLE
Revert duplicate pre-commit monthly config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,3 @@ repos:
     rev: "6.0.0"
     hooks:
       - id: flake8
-
-# pre-commit.ci config reference: https://pre-commit.ci/#configuration
-ci:
-  autoupdate_schedule: monthly


### PR DESCRIPTION
This reverts commit 350be9a964af7a03ca6f3a8902b886d97c2f5c21

which added a duplicate field, already added in #93 