### PR TITLE
Add tests against dockerd on the host system (k8s cordining/uncording not tested)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,8 +45,14 @@ jobs:
           pip freeze
 
       - name: Run pytest
+        # if pytest is run without sudo, it won't have permissions to inspect
+        # /var/lib/docker and can't decide on when to clean etc either.
+        #
+        # FIXME: docker image cleaner should realize it doesn't have permissions
+        #        to estimate the disk usage in get_absolute_size
+        #
         run: |
-          pytest --maxfail=2 --cov=docker_image_cleaner
+          sudo -E PATH=$PATH bash -c "pytest --maxfail=2 --cov=docker_image_cleaner"
 
       # GitHub action reference: https://github.com/codecov/codecov-action
       - uses: codecov/codecov-action@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,7 +51,10 @@ jobs:
       - name: Install Python dependencies
         run: |
           pip install --upgrade pip
-          pip install -r dev-requirements.txt .
+          pip install -e ".[test]"
+
+      - name: List Python dependencies
+        run: |
           pip freeze
 
       - name: Run pytest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,61 @@
+name: Test
+
+on:
+  pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - ".github/workflows/*"
+      - "!.github/workflows/test.yaml"
+  push:
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - ".github/workflows/*"
+      - "!.github/workflows/test.yaml"
+    branches-ignore:
+      - "dependabot/**"
+      - "pre-commit-ci-update-config"
+    tags:
+      - "**"
+  workflow_dispatch:
+
+env:
+  # UTF-8 content may be interpreted as ascii and causes errors without this.
+  LANG: C.UTF-8
+  PYTEST_ADDOPTS: "--verbose --color=yes"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 15
+
+    strategy:
+      matrix:
+        python:
+          - "3.10"
+
+    steps:
+      - uses: actions/checkout@v3
+
+      # NOTE: actions/setup-python@v4 make use of a cache within the GitHub base
+      #       environment and setup in a fraction of a second.
+      - name: Install Python ${{ matrix.python }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: "${{ matrix.python }}"
+
+      - name: Install Python dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -r dev-requirements.txt .
+          pip freeze
+
+      - name: Run pytest
+        run: |
+          pytest --maxfail=2 --cov=docker_image_cleaner tests
+
+      - uses: codecov/codecov-action@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,8 +26,20 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # We run tests against various versions of the docker api provided by
+          # dockerd, itself running inside a docker container on the host
+          # system.
+          #
+          # ref: https://hub.docker.com/_/docker/tags?page=1&name=dind
+          #
           - python-version: "3.8"
+            docker-api-providing-image: docker:20-dind
+          - python-version: "3.9"
+            docker-api-providing-image: docker:23-dind
+          - python-version: "3.10"
+            docker-api-providing-image: docker:24-dind
           - python-version: "3.11"
+            docker-api-providing-image: docker:dind
 
     steps:
       - uses: actions/checkout@v3
@@ -45,14 +57,12 @@ jobs:
           pip freeze
 
       - name: Run pytest
-        # if pytest is run without sudo, it won't have permissions to inspect
-        # /var/lib/docker and can't decide on when to clean etc either.
-        #
-        # FIXME: docker image cleaner should realize it doesn't have permissions
-        #        to estimate the disk usage in get_absolute_size
+        # pytest is run with sudo, as it seems to need it for permissions to
+        # inspect /var/lib/docker and cleanup built images after tests complete
+        # without erroring.
         #
         run: |
-          sudo -E PATH=$PATH bash -c "pytest --maxfail=2 --cov=docker_image_cleaner"
+          sudo -E PATH=$PATH bash -c "pytest --docker-api-providing-image=${{ matrix.docker-api-providing-image }} --cov=docker_image_cleaner"
 
       # GitHub action reference: https://github.com/codecov/codecov-action
       - uses: codecov/codecov-action@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,13 +3,11 @@ name: Test
 on:
   pull_request:
     paths-ignore:
-      - "docs/**"
       - "**.md"
       - ".github/workflows/*"
       - "!.github/workflows/test.yaml"
   push:
     paths-ignore:
-      - "docs/**"
       - "**.md"
       - ".github/workflows/*"
       - "!.github/workflows/test.yaml"
@@ -20,33 +18,22 @@ on:
       - "**"
   workflow_dispatch:
 
-env:
-  # UTF-8 content may be interpreted as ascii and causes errors without this.
-  LANG: C.UTF-8
-  PYTEST_ADDOPTS: "--verbose --color=yes"
-
-permissions:
-  contents: read
-
 jobs:
   test:
-    runs-on: ubuntu-20.04
-    timeout-minutes: 15
+    runs-on: ubuntu-22.04
 
     strategy:
+      fail-fast: false
       matrix:
-        python:
-          - "3.10"
+        include:
+          - python-version: "3.8"
+          - python-version: "3.11"
 
     steps:
       - uses: actions/checkout@v3
-
-      # NOTE: actions/setup-python@v4 make use of a cache within the GitHub base
-      #       environment and setup in a fraction of a second.
-      - name: Install Python ${{ matrix.python }}
-        uses: actions/setup-python@v4
+      - uses: actions/setup-python@v4
         with:
-          python-version: "${{ matrix.python }}"
+          python-version: "${{ matrix.python-version }}"
 
       - name: Install Python dependencies
         run: |
@@ -59,6 +46,7 @@ jobs:
 
       - name: Run pytest
         run: |
-          pytest --maxfail=2 --cov=docker_image_cleaner tests
+          pytest --maxfail=2 --cov=docker_image_cleaner
 
+      # GitHub action reference: https://github.com/codecov/codecov-action
       - uses: codecov/codecov-action@v3

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Docker Image Cleaner
 
-[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/jupyterhub/docker-image-cleaner/Publish?logo=github)](https://github.com/jupyterhub/docker-image-cleaner/actions)
 [![Latest PyPI version](https://img.shields.io/pypi/v/docker-image-cleaner?logo=pypi)](https://pypi.python.org/pypi/docker-image-cleaner)
 [![Latest quay.io image tags](https://img.shields.io/github/v/tag/jupyterhub/docker-image-cleaner?include_prereleases&label=quay.io)](https://quay.io/repository/jupyterhub/docker-image-cleaner?tab=tags)
+[![GitHub Workflow Status - Test](https://img.shields.io/github/actions/workflow/status/jupyterhub/docker-image-cleaner/test.yaml?logo=github&label=tests)](https://github.com/jupyterhub/docker-image-cleaner/actions)
+[![Test coverage of code](https://codecov.io/gh/jupyterhub/docker-image-cleaner/branch/main/graph/badge.svg)](https://codecov.io/gh/jupyterhub/docker-image-cleaner)
+[![Issue tracking - GitHub](https://img.shields.io/badge/issue_tracking-github-blue?logo=github)](https://github.com/jupyterhub/docker-image-cleaner/issues)
+[![Help forum - Discourse](https://img.shields.io/badge/help_forum-discourse-blue?logo=discourse)](https://discourse.jupyter.org/c/jupyterhub)
 
 A Python package (`docker-image-cleaner`) and associated Docker image
 (`quay.io/jupyterhub/docker-image-cleaner`) to clean up old docker images when a

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,0 @@
-# pip-tools include pip-compile that can be useful to manually update
-# requirements.txt based on requirements.in using the command "pip-compile"
-pip-tools

--- a/docker_image_cleaner/cleaner.py
+++ b/docker_image_cleaner/cleaner.py
@@ -151,8 +151,8 @@ def main():
     elif threshold_type == "absolute":
         get_used = get_absolute_size
         used_msg = "{used:.2f}GB used"
-        threshold_s = f"{threshold_high // GB:.0f}GB"
-        if threshold_high <= 2**30:
+        threshold_s = f"{threshold_high / GB:.2f}GB"
+        if threshold_high < GB:
             raise ValueError(
                 f"Absolute GC threshold should be at least 1GB, got {threshold_high}B"
             )

--- a/docker_image_cleaner/cleaner.py
+++ b/docker_image_cleaner/cleaner.py
@@ -137,6 +137,14 @@ def main():
     threshold_high = float(os.getenv("DOCKER_IMAGE_CLEANER_THRESHOLD_HIGH", "80"))
     timeout_seconds = int(os.getenv("DOCKER_IMAGE_CLEANER_TIMEOUT_SECONDS", "300"))
 
+    logging.info("Starting docker image cleaning with the following settings:")
+    logging.info(f"DOCKER_IMAGE_CLEANER_PATH_TO_CHECK={path_to_check}")
+    logging.info(f"DOCKER_IMAGE_CLEANER_INTERVAL_SECONDS={interval_seconds}")
+    logging.info(f"DOCKER_IMAGE_CLEANER_DELAY_SECONDS={delay_seconds}")
+    logging.info(f"DOCKER_IMAGE_CLEANER_THRESHOLD_TYPE={threshold_type}")
+    logging.info(f"DOCKER_IMAGE_CLEANER_THRESHOLD_HIGH={threshold_high}")
+    logging.info(f"DOCKER_IMAGE_CLEANER_TIMEOUT_SECONDS={timeout_seconds}")
+
     docker_client = docker.from_env(version="auto", timeout=timeout_seconds)
 
     # with the threshold type set to relative the thresholds are interpreted

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,12 @@ target_version = [
     "py310",
     "py311",
 ]
+
+
+# pytest is used for running Python based tests
+#
+# ref: https://docs.pytest.org/en/stable/
+#
+[tool.pytest.ini_options]
+addopts = "--verbose --color=yes --durations=10"
+testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,5 +37,5 @@ target_version = [
 # ref: https://docs.pytest.org/en/stable/
 #
 [tool.pytest.ini_options]
-addopts = "--verbose --color=yes --durations=10"
+addopts = "--verbose --color=yes --maxfail=2 --durations=10"
 testpaths = ["tests"]

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,8 @@
-# This file is automatically maintained by Dependabot, as configured in
-# .github/dependabot.yaml.
+# These are dependencies for the Python package, which are frozen into
+# requirements.txt for use by the Dockerfile using a GitHub Workflow that can be
+# manually triggered from
+# https://github.com/jupyterhub/docker-image-cleaner/actions/workflows/refreeze-dockerfile-requirements-txt.yaml.
 #
 docker
 kubernetes
+requests

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ setup(
     # SemVer 2: https://semver.org
     #
     version="1.0.0-beta.3",
-    python_requires=">=3.8",
     author="Project Jupyter Contributors",
     author_email="jupyter@googlegroups.com",
     license="BSD",
@@ -24,10 +23,17 @@ setup(
     description="Cleanup old docker images to free up disk space and inodes",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
-    install_requires=requirements,
     entry_points={
         "console_scripts": [
             "docker-image-cleaner = docker_image_cleaner.__main__:main",
         ]
+    },
+    python_requires=">=3.8",
+    install_requires=requirements,
+    extras_require={
+        "test": [
+            "pytest",
+            "pytest-cov",
+        ],
     },
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,7 @@ def host_docker():
 
 @pytest.fixture(scope="session")
 def dind_image(host_docker):
-    dind_image = "docker:20-dind"
+    dind_image = "docker:24-dind"
     host_docker.images.pull(dind_image)
     return dind_image
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import sys
 import time
@@ -6,6 +7,8 @@ from unittest import mock
 import docker
 import pytest
 import requests
+
+logging.basicConfig(format="%(asctime)s %(message)s", level=logging.INFO)
 
 dind_container_name = "test-image-cleaner-dind"
 
@@ -56,6 +59,7 @@ def dind(tmpdir, host_docker, dind_image, dind_dir):
     work against it, exposed via the network on port 2376.
 
     docker client ref: https://docker-py.readthedocs.io/en/stable/client.html
+    docker container.run ref: https://docker-py.readthedocs.io/en/stable/containers.html#docker.models.containers.ContainerCollection.run
     """
     # start the container
     dind_mount = docker.types.Mount(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,167 @@
+import os
+import sys
+import time
+from unittest import mock
+
+import docker
+import pytest
+import requests
+
+dind_container_name = "test-image-cleaner-dind"
+
+
+@pytest.fixture(scope="session")
+def host_docker():
+    d = docker.from_env()
+    d.images.pull("ubuntu:22.04")
+    # make sure there isn't a lingering dind container
+    try:
+        dind_container = d.containers.get(dind_container_name)
+    except docker.errors.NotFound:
+        pass
+    else:
+        try:
+            dind_container.stop()
+        except docker.errors.NotFound:
+            pass
+        else:
+            try:
+                dind_container.remove()
+            except docker.errors.NotFound:
+                pass
+    return d
+
+
+@pytest.fixture(scope="session")
+def dind_image(host_docker):
+    dind_image = "docker:20-dind"
+    host_docker.images.pull(dind_image)
+    return dind_image
+
+
+@pytest.fixture
+def dind_dir(tmpdir):
+    dind_dir = str(tmpdir.mkdir("dind"))
+    with mock.patch.dict(
+        os.environ, {"DOCKER_IMAGE_CLEANER_PATH_TO_CHECK": str(dind_dir)}
+    ):
+        yield str(dind_dir)
+
+
+@pytest.fixture
+def dind(tmpdir, host_docker, dind_image, dind_dir):
+    """Start docker-in-docker (dind)"""
+    # start the container
+    dind_mount = docker.types.Mount(
+        type="bind",
+        target="/var/lib/docker",
+        source=dind_dir,
+        read_only=False,
+    )
+    dind_container = host_docker.containers.run(
+        dind_image,
+        name=dind_container_name,
+        privileged=True,
+        mounts=[dind_mount],
+        command=[
+            "dockerd",
+            "--host=tcp://0.0.0.0:2376",
+            "--tls=false",
+        ],
+        detach=True,
+        ports={"2376/tcp": ("127.0.0.1", None)},
+    )
+    # start streaming logs from the container
+    def stream_logs():
+        for line in dind_container.logs(stream=True):
+            sys.stderr.write(line.decode("utf8", "replace"))
+
+    from threading import Thread
+
+    log_thread = Thread(target=stream_logs)
+    log_thread.start()
+
+    # wait for ports to be ready
+    while not dind_container.ports:
+        dind_container.reload()
+
+    port = dind_container.ports["2376/tcp"][0]["HostPort"]
+    docker_host = f"tcp://127.0.0.1:{port}"
+
+    with mock.patch.dict(os.environ, {"DOCKER_HOST": docker_host}):
+        # wait for docker to start
+        deadline = time.monotonic() + 30
+        dind_client = None
+        while time.monotonic() < deadline:
+            try:
+                result = dind_container.wait(timeout=1)
+            except (
+                requests.exceptions.ReadTimeout,
+                requests.exceptions.ConnectionError,
+            ):
+                pass
+            else:
+                log_thread.join(timeout=1)
+                pytest.fail(f"dind container exited! {result=}")
+            try:
+                dind_client = docker.from_env()
+            except Exception as e:
+                print(f"dind not ready: {e}")
+                continue
+            else:
+                break
+        assert dind_client is not None
+        try:
+            yield dind_client
+        except Exception as e:
+            print("Exception! {e}")
+
+    # stop and remove
+    try:
+        dind_container.stop()
+    except docker.errors.NotFound:
+        pass
+    try:
+        dind_container.remove()
+    except docker.errors.NotFound:
+        pass
+
+    # cleanup dind dir: needs root! pytest cleanup will fail with permission errors
+    out = host_docker.containers.run(
+        "ubuntu:22.04",
+        remove=True,
+        mounts=[dind_mount],
+        command=[
+            "sh",
+            "-c",
+            f"rm -rf {dind_mount['Target']}/*",
+        ],
+    )
+
+
+@pytest.fixture
+def absolute_threshold():
+    """Use absolute threshold
+
+    get_used is hard
+    """
+    with mock.patch.dict(
+        os.environ, {"DOCKER_IMAGE_CLEANER_THRESHOLD_TYPE": "absolute"}
+    ):
+        yield
+
+
+class Slept(Exception):
+    """Exception for raising instead of sleeping"""
+
+    def __init__(self, slept_for):
+        self.slept_for = slept_for
+
+
+@pytest.fixture
+def sleep_stops():
+    def raise_slept(t):
+        raise Slept(t)
+
+    with mock.patch("time.sleep", raise_slept):
+        yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,6 +71,7 @@ def dind(tmpdir, host_docker, dind_image, dind_dir):
         detach=True,
         ports={"2376/tcp": ("127.0.0.1", None)},
     )
+
     # start streaming logs from the container
     def stream_logs():
         for line in dind_container.logs(stream=True):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,28 @@ logging.basicConfig(format="%(asctime)s %(message)s", level=logging.INFO)
 dind_container_name = "test-image-cleaner-dind"
 
 
+def pytest_addoption(parser, pluginmanager):
+    """
+    A pytest hook to register argparse-style options and ini-style config
+    values.
+
+    We use it to declare command-line arguments.
+
+    ref: https://docs.pytest.org/en/stable/reference/reference.html#pytest.hookspec.pytest_addoption
+    ref: https://docs.pytest.org/en/stable/reference/reference.html#pytest.Parser.addoption
+    """
+    parser.addoption(
+        "--docker-api-providing-image",
+        default="docker:dind",
+        help=(
+            "We run tests against various versions of the docker api provided "
+            "by dockerd itself running inside a docker container on the host "
+            "system. Tests rely on a docker api provided by a daemon running "
+            "inside a container started using this image."
+        ),
+    )
+
+
 @pytest.fixture(scope="session")
 def host_docker():
     d = docker.from_env()
@@ -36,8 +58,8 @@ def host_docker():
 
 
 @pytest.fixture(scope="session")
-def dind_image(host_docker):
-    dind_image = "docker:24-dind"
+def dind_image(host_docker, pytestconfig):
+    dind_image = pytestconfig.getoption("--docker-api-providing-image")
     host_docker.images.pull(dind_image)
     return dind_image
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,7 +50,13 @@ def dind_dir(tmpdir):
 
 @pytest.fixture
 def dind(tmpdir, host_docker, dind_image, dind_dir):
-    """Start docker-in-docker (dind)"""
+    """
+    This fixture starts a docker container (docker-in-docker aka. dind) on the
+    host system running a docker daemon (dockerd), and yield a docker client to
+    work against it, exposed via the network on port 2376.
+
+    docker client ref: https://docker-py.readthedocs.io/en/stable/client.html
+    """
     # start the container
     dind_mount = docker.types.Mount(
         type="bind",

--- a/tests/test-image/Dockerfile
+++ b/tests/test-image/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:22.04
+#  FAIL: build fails (leaves dangling image)
+ARG FAIL=0
+# SIZE_KB: size of intermediate layer in kB (created with dd)
+ARG SIZE_MB=1000
+USER root
+RUN dd if=/dev/zero bs=1M count=$SIZE_MB
+RUN exit $FAIL

--- a/tests/test-image/Dockerfile
+++ b/tests/test-image/Dockerfile
@@ -6,6 +6,6 @@ ARG FAIL=0
 ARG SIZE_MB=1000
 
 USER root
-RUN dd if=/dev/zero bs=1M count=$SIZE_MB
+RUN dd if=/dev/urandom bs=1M count=$SIZE_MB of=newfile
 
 RUN exit $FAIL

--- a/tests/test-image/Dockerfile
+++ b/tests/test-image/Dockerfile
@@ -1,8 +1,11 @@
 FROM ubuntu:22.04
-#  FAIL: build fails (leaves dangling image)
+
+# FAIL: build fails (leaves dangling image layers)
 ARG FAIL=0
 # SIZE_KB: size of intermediate layer in kB (created with dd)
 ARG SIZE_MB=1000
+
 USER root
 RUN dd if=/dev/zero bs=1M count=$SIZE_MB
+
 RUN exit $FAIL

--- a/tests/test_cleaner.py
+++ b/tests/test_cleaner.py
@@ -1,0 +1,130 @@
+import os
+from pathlib import Path
+from unittest import mock
+
+import docker
+import pytest
+from conftest import Slept
+
+from docker_image_cleaner import cleaner
+
+here = Path(__file__).resolve().parent
+test_image = here.joinpath("test-image")
+
+
+def build_image(docker_client, tag, size_mb=1_000, fail=0):
+    try:
+        docker_client.images.build(
+            path=str(test_image),
+            tag=tag,
+            buildargs={
+                "SIZE_MB": str(size_mb),
+                "FAIL": str(fail),
+            },
+        )
+    except docker.errors.BuildError:
+        if not fail:
+            raise
+    else:
+        if fail:
+            raise RuntimeError("Should have failed!")
+
+
+def make_file(path, size_mb):
+    with open("/dev/zero", "rb") as r:
+        mb = r.read(2**20)
+
+    with open(path, "wb") as f:
+        for i in range(size_mb):
+            f.write(mb)
+    return path
+
+
+def test_get_used_percent():
+    used = cleaner.get_used_percent("/")
+    # assert range, not much else we can check here
+    assert 0 < used < 100
+
+
+def test_get_absolute_size(tmpdir):
+    test_path = tmpdir.mkdir("test")
+
+    def get_used():
+        return cleaner.get_absolute_size(str(test_path))
+
+    assert get_used() == 0
+    # add a 1GB file
+    make_file(test_path.join("1gb"), 1024)
+    assert 0.9 < get_used() < 1.1
+    # add another 1GB file
+    make_file(test_path.join("1gb.2"), 1024)
+    assert 1.9 < get_used() < 2.2
+
+
+def test_ps(dind):
+    assert dind.images.list() == []
+
+
+def test_nothing_to_clean(dind, absolute_threshold, sleep_stops):
+    dind.images.pull("ubuntu:22.04")
+    with mock.patch.dict(
+        os.environ, {"DOCKER_IMAGE_CLEANER_THRESHOLD_HIGH": "2e9"}
+    ), pytest.raises(Slept):
+        cleaner.main()
+
+    assert [image.name for image in dind.images.list()] == ["ubuntu:22.04"]
+
+
+def test_clean_dangling(dind, absolute_threshold, sleep_stops):
+    dind.images.pull("ubuntu:22.04")
+
+    def get_images(**kwargs):
+        return sorted(tuple(image.tags) for image in dind.images.list(**kwargs))
+
+    before_build = get_images()
+    before_build_all = get_images(all=True)
+
+    build_image(dind, tag="unused", size_mb=2_000, fail=1)
+    assert get_images() == before_build  # no new tagged image
+    # but there is something still to prune
+    assert len(get_images(all=True)) > len(before_build_all)
+
+    # run clean
+    with mock.patch.dict(
+        os.environ, {"DOCKER_IMAGE_CLEANER_THRESHOLD_HIGH": "2e9"}
+    ), pytest.raises(Slept):
+        cleaner.main()
+
+    # did not delete pre-existing image
+    assert get_images() == before_build
+    # but did delete dangling images
+    assert get_images(all=True) == before_build_all
+
+
+def test_clean_all(dind, absolute_threshold, sleep_stops):
+    dind.images.pull("ubuntu:22.04")
+
+    def get_images(**kwargs):
+        return sorted(tuple(image.tags) for image in dind.images.list(**kwargs))
+
+    before_build = get_images()
+    before_build_all = get_images(all=True)
+
+    # build two images, one that fails (leaves dangles)
+    # and one that succeeds
+    build_image(dind, tag="unused", size_mb=1_000, fail=1)
+    build_image(dind, tag="2gb", size_mb=2_000, fail=0)
+    after_build = ["2gb"] + get_images()
+    assert get_images() == after_build
+
+    # run clean with 2GB
+    with mock.patch.dict(
+        os.environ, {"DOCKER_IMAGE_CLEANER_THRESHOLD_HIGH": "2e9"}
+    ), pytest.raises(Slept):
+        cleaner.main()
+
+    # dangling images wasn't enough, pruned everything
+    # did not delete pre-existing image
+    assert get_images() == []
+    # but did delete dangling images
+    assert get_images(all=True) == []

--- a/tests/test_cleaner.py
+++ b/tests/test_cleaner.py
@@ -104,7 +104,7 @@ def test_get_absolute_size(tmpdir):
     assert 1.9 < get_used() < 2.2
 
 
-def test_nothing_to_clean(dind, dind_dir, absolute_threshold, sleep_stops):
+def test_clean_nothing(dind, dind_dir, absolute_threshold, sleep_stops):
     """
     Tests pulling an image and running the cleaner with a high enough threshold
     for the pulled image not be cleaned.
@@ -130,6 +130,11 @@ def test_nothing_to_clean(dind, dind_dir, absolute_threshold, sleep_stops):
 
 
 def test_clean_dangling(dind, dind_dir, absolute_threshold, sleep_stops):
+    """
+    Tests pulling an image, creating dangling image layers, and running the
+    cleaner with a high enough threshold for the pulled image not be cleaned
+    after the dangling image layers was cleaned.
+    """
     assert 0.1 > cleaner.get_absolute_size(dind_dir)
 
     dind.images.pull("ubuntu:22.04")
@@ -157,6 +162,11 @@ def test_clean_dangling(dind, dind_dir, absolute_threshold, sleep_stops):
 
 
 def test_clean_all(dind, dind_dir, absolute_threshold, sleep_stops):
+    """
+    Tests pulling an image, creating dangling image layers and a non-dangling
+    image, then running the cleaner forced to clean up non-dangling image layers
+    as well.
+    """
     dind.images.pull("ubuntu:22.04")
     assert 1 > cleaner.get_absolute_size(dind_dir) > 0.1
 


### PR DESCRIPTION
started working on these, but it immediately became difficult to run tests locally because I haven't been able to get docker-in-docker to work with a mounted docker directory (presumably a docker-on-mac issue). Shouldn't be a problem on true linux, though.

closes #16