### PR TITLE
ci: monthly dependabot updates and pip-compile based refreezes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,7 +27,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/" # This should be / rather than .github/workflows
     schedule:
-      interval: daily
+      interval: monthly
       time: "05:00"
       timezone: "Etc/UTC"
     labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,19 +10,6 @@
 
 version: 2
 updates:
-  # Maintain Python dependencies for the quay.io/jupyterhub/docker-image-cleaner
-  # image
-  - package-ecosystem: pip
-    directory: "/"
-    schedule:
-      interval: daily
-      time: "00:00"
-      timezone: "Etc/UTC"
-    versioning-strategy: lockfile-only
-    labels:
-      - maintenance
-      - dependencies
-
   # Maintain dependencies in our GitHub Workflows
   - package-ecosystem: "github-actions"
     directory: "/" # This should be / rather than .github/workflows

--- a/.github/workflows/refreeze-dockerfile-requirements-txt.yaml
+++ b/.github/workflows/refreeze-dockerfile-requirements-txt.yaml
@@ -10,6 +10,9 @@ on:
       - "**/requirements.txt"
       - ".github/workflows/refreeze-dockerfile-requirements-txt.yaml"
     branches: ["main"]
+  schedule:
+    # Run 05:00 the first day of the month ref: https://crontab.guru/#0_5_1_*_*
+    - cron: "0 5 1 * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
- I think its better if we refreeze on a monthly basis using our refreeze script based on pip-compile (from pip-tools) than using dependabot to update requirements.txt from time to time. This makes it so.
- I recall agreement in jupyterhub/team-compass to update github actions on a monthly basis. This makes it so.