### PR TITLE
get_absolute_size should raise if it can't find anything

### DIFF
--- a/docker_image_cleaner/cleaner.py
+++ b/docker_image_cleaner/cleaner.py
@@ -28,6 +28,9 @@ def get_absolute_size(path):
     """
     Directory size in gigabytes
     """
+    # first, check permissions, existence of path with os.listdir
+    # os.walk returns an empty list if it doesn't find anything
+    os.listdir(path)
     total = 0
     for dirpath, dirnames, filenames in os.walk(path):
         for fname in filenames:

--- a/tests/test_cleaner.py
+++ b/tests/test_cleaner.py
@@ -195,3 +195,8 @@ def test_clean_all(dind, dind_dir, absolute_threshold, sleep_stops):
     # everything goes at this point
     assert 0.1 > cleaner.get_absolute_size(dind_dir)
     assert _get_image_tags(dind) == []
+
+
+def test_get_absolute_size_no_such_dir(tmpdir):
+    with pytest.raises(FileNotFoundError):
+        cleaner.get_absolute_size(tmpdir.join("nosuchdir"))


### PR DESCRIPTION
can't directly test PermissionError, but it's easy enough to see it will happen. Tested with FileNotFoundError, which exercises the same case (get_absolute_size returns 0 if the path doesn't exist).

closes #124 