### PR TITLE
refactoring: specify log level via pytest config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,4 +38,5 @@ target_version = [
 #
 [tool.pytest.ini_options]
 addopts = "--verbose --color=yes --maxfail=2 --durations=10"
+log_level = "INFO"
 testpaths = ["tests"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import sys
 import time
@@ -7,8 +6,6 @@ from unittest import mock
 import docker
 import pytest
 import requests
-
-logging.basicConfig(format="%(asctime)s %(message)s", level=logging.INFO)
 
 dind_container_name = "test-image-cleaner-dind"
 


### PR DESCRIPTION
Pytest's default log level is WARNING, making the info statements not show up when running tests. To get logs to show not understanding this, I put `logging.basicConfig(format="%(asctime)s %(message)s", level=logging.INFO)` inside conftest.py.

Lets instead specify the log level via pytest config.