### PR TITLE
Fix for #191

### DIFF
--- a/docker_image_cleaner/cleaner.py
+++ b/docker_image_cleaner/cleaner.py
@@ -54,8 +54,8 @@ def get_used_percent(path):
     which ever reports as the most full.
     """
     stat = os.statvfs(path)
-    inodes_avail = stat.f_favail / stat.f_files
-    blocks_avail = stat.f_bavail / stat.f_blocks
+    inodes_avail = stat.f_favail / stat.f_files if stat.f_files > 0 else 1.0
+    blocks_avail = stat.f_bavail / stat.f_blocks if stat.f_blocks > 0 else 1.0
     return 100 * (1 - min(blocks_avail, inodes_avail))
 
 


### PR DESCRIPTION
Depending on the filesystem type, it's possible for python to try to divide by zero, which throws an error and crashes the pod. This just adds a simple inline check to change the value from 0 to 1 if that happens to be the case. 

### Checklist

- [x] I am the author of this work

### What does this PR do?
<!--
Please indicate the type of change made by this PR (tick one or more of the boxes) and summarise the PR.
Please also edit the PR title so that it contains enough context to go into a changelog.
It may help to list each change with an explanation of why it's needed- remember that what seems obvious to you may not be obvious to a reviewer.
-->
Type of change:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Other

### Is this PR related to an issue, or is it part of a larger body of work?

Simple fix for #191 

### Does this PR introduce a breaking change?

No

### How can this PR be tested?

Honestly I don't know. It's a bit of an edge case and I suspect that there are no current automated tests for this repo/image considering the last update to the image was 4 years ago. 
